### PR TITLE
Example fixes

### DIFF
--- a/Application/src/main/java/com/example/android/bluetoothlegatt/BluetoothLeService.java
+++ b/Application/src/main/java/com/example/android/bluetoothlegatt/BluetoothLeService.java
@@ -290,6 +290,7 @@ public class BluetoothLeService extends Service {
      */
     public void setCharacteristicNotification(BluetoothGattCharacteristic characteristic,
                                               boolean enabled) {
+        int writeType;
         if (mBluetoothAdapter == null || mBluetoothGatt == null) {
             Log.w(TAG, "BluetoothAdapter not initialized");
             return;
@@ -298,12 +299,18 @@ public class BluetoothLeService extends Service {
 
         BluetoothGattDescriptor descriptor = characteristic.getDescriptor(
                 UUID.fromString(SampleGattAttributes.CLIENT_CHARACTERISTIC_CONFIG));
+        writeType = characteristic.getWriteType();
+        // Workaround for Issue 150933:
+        // "BluetoothGatt.writeDescriptor uses the corresponding characteristic's write type"
+        // https://code.google.com/p/android/issues/detail?id=150933
+        characteristic.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
         if (enabled) {
             descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
         } else {
             descriptor.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE);
         }
         mBluetoothGatt.writeDescriptor(descriptor);
+        characteristic.setWriteType(writeType);
     }
 
     /**

--- a/Application/src/main/java/com/example/android/bluetoothlegatt/BluetoothLeService.java
+++ b/Application/src/main/java/com/example/android/bluetoothlegatt/BluetoothLeService.java
@@ -296,13 +296,14 @@ public class BluetoothLeService extends Service {
         }
         mBluetoothGatt.setCharacteristicNotification(characteristic, enabled);
 
-        // This is specific to Heart Rate Measurement.
-        if (UUID_HEART_RATE_MEASUREMENT.equals(characteristic.getUuid())) {
-            BluetoothGattDescriptor descriptor = characteristic.getDescriptor(
-                    UUID.fromString(SampleGattAttributes.CLIENT_CHARACTERISTIC_CONFIG));
+        BluetoothGattDescriptor descriptor = characteristic.getDescriptor(
+                UUID.fromString(SampleGattAttributes.CLIENT_CHARACTERISTIC_CONFIG));
+        if (enabled) {
             descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
-            mBluetoothGatt.writeDescriptor(descriptor);
+        } else {
+            descriptor.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE);
         }
+        mBluetoothGatt.writeDescriptor(descriptor);
     }
 
     /**

--- a/Application/src/main/java/com/example/android/bluetoothlegatt/DeviceControlActivity.java
+++ b/Application/src/main/java/com/example/android/bluetoothlegatt/DeviceControlActivity.java
@@ -126,7 +126,11 @@ public class DeviceControlActivity extends Activity {
                         final BluetoothGattCharacteristic characteristic =
                                 mGattCharacteristics.get(groupPosition).get(childPosition);
                         final int charaProp = characteristic.getProperties();
-                        if ((charaProp | BluetoothGattCharacteristic.PROPERTY_READ) > 0) {
+                        if ((charaProp & BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0) {
+                            mNotifyCharacteristic = characteristic;
+                            mBluetoothLeService.setCharacteristicNotification(
+                                    characteristic, true);
+                        } else if ((charaProp & BluetoothGattCharacteristic.PROPERTY_READ) > 0) {
                             // If there is an active notification on a characteristic, clear
                             // it first so it doesn't update the data field on the user interface.
                             if (mNotifyCharacteristic != null) {
@@ -135,11 +139,6 @@ public class DeviceControlActivity extends Activity {
                                 mNotifyCharacteristic = null;
                             }
                             mBluetoothLeService.readCharacteristic(characteristic);
-                        }
-                        if ((charaProp | BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0) {
-                            mNotifyCharacteristic = characteristic;
-                            mBluetoothLeService.setCharacteristicNotification(
-                                    characteristic, true);
                         }
                         return true;
                     }


### PR DESCRIPTION
1. Add CCCD (Client Characteristic Configuration Descriptor) write when enabling notifications

2. Remove read when enabling notifications
Avoid issuing multiple GATT commands. The BluetoothGatt API does not support command queuing.

3. Add workaround for issue 150933: BluetoothGatt.writeDescriptor uses the corresponding characteristic's write type
https://code.google.com/p/android/issues/detail?id=150933
